### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ glip = Poster(YOUR_WEBHOOK_URL, icon: "http://example.com/icon.png")
 glip.sendMessage("Hi there!")
 ```
 
-## Supported Swift / XCode Versions
+## Supported Swift / Xcode Versions
 
 This library supports the following Xcode / Swift implementations:
 


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
